### PR TITLE
Support builds with dotnet and Rider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ bld/
 [Ll]og/
 [Ll]ogs/
 
+# JetBrains settings
+.idea/
+
 # Visual Studio 2015/2017 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot

--- a/src/CommonLib/CommonLib.csproj
+++ b/src/CommonLib/CommonLib.csproj
@@ -18,11 +18,11 @@
 
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>$(PublicLibsFolder)/Assembly-CSharp.dll</HintPath>
+      <HintPath>$(GameLibsFolder)/Assembly-CSharp.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>$(PublicLibsFolder)/Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>$(GameLibsFolder)/Assembly-CSharp-firstpass.dll</HintPath>
       <Private>false</Private>
     </Reference>
     <Reference Include="0Harmony">

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -29,7 +29,7 @@ APIVersion: 2"
       <InputAssemblies Include="$(TargetPath)"/>
     </ItemGroup>
     <ItemGroup Condition="'$(UseCommonLib)' == 'true'">
-      <InputAssemblies Include="@(InputAssemblies);$(TargetDir)RomenH.CommonLib.dll"/>
+      <InputAssemblies Include="@(InputAssemblies);$(TargetDir)CommonLib.dll"/>
     </ItemGroup>
     <ItemGroup Condition="'$(UsePLib)' == 'true'">
       <InputAssemblies Include="@(InputAssemblies);$(TargetDir)PLib.dll"/>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -35,7 +35,7 @@ APIVersion: 2"
       <InputAssemblies Include="@(InputAssemblies);$(TargetDir)PLib.dll"/>
     </ItemGroup>
 
-    <ILRepack TargetPlatformVersion="v4"
+    <ILRepack
               TargetKind="SameAsPrimaryAssembly"
               OutputFile="$(TargetPath)"
               InputAssemblies="@(InputAssemblies)"


### PR DESCRIPTION
Hi Romen,

To build this solution with dotnet and Rider, we apply the following commits:

1. e57a56b340500cb3b555e477cefef25762d95aea Fixes the current build[^1].
2. 9574073458b28a7838a9d178a00d839476c5e4b0 Enables building with dotnet[^2].
3. 1399eecf551fc37428b4868c175cdd06a79dea0e Updates `.gitignore` for Rider settings.

To support dotnet builds, commit (2) is relevant. To support Rider builds, commit (3) is relevant. Trivially, commit (1) is required to build in all cases. The commits are separated for convenient editing or arrangement.

[^1]: The current build misses some MSBuild properties for 'gamelibs'. Also 'CommonLib.dll' was referenced as 'Romen.CommonLib.dll'.
[^2]: The ILRepack parameter `TargetPlatformVersion` restricts usage to MSBuild on .NET Framework. However, `dotnet build` uses MSBuild on .NET (Core).

### Tests

To verify that the build runs, we tested against two versions of MSBuild with the appropriate configurations and platforms:

1. Visual Studio 2022 MSBuild using `%ProgramFiles(x86)%\Microsoft Visual Studio\2022\BuildTools\MSBuild\Current\Bin\MSBuild.exe -t:Build`
2. dotnet using `dotnet build`

To visually explore the build, see the attached [binlog](https://github.com/user-attachments/files/19613747/Binlog.zip).